### PR TITLE
Add option to authenticate bearer token

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ COPY ./script/entrypoint /entrypoint
 RUN apk add --no-cache curl python3 openssl && \
     curl https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py && \
     python3 /tmp/get-pip.py && \
-    pip install /tmp/dummyserver.tar.gz && \
+    pip install requests /tmp/dummyserver.tar.gz && \
     rm -f /tmp/get-pip.py /tmp/dummyserver.tar.gz
 
 EXPOSE 8080 8181 8282 8383

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = dummyserver
-version = 0.5.0
+version = 0.6.0
 summary = Dummy Web Server
 description-file =
     README.md

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
 setuptools.setup(
-    python_requires='>3.6.0',
+    python_requires='>3.7.0',
     setup_requires=['pbr>=2.0.0'],
     pbr=True)


### PR DESCRIPTION
This adds the option to authenticate to the webserver using a bearer token.

To configure this, an INTROSPECT_URL should be specified via an environment variable.  Authentication credentials containing a token will be queried against this URL.